### PR TITLE
Fix startup failure when mounting /var/drydock

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-mkdir /var/drydock
+mkdir -p /var/drydock
 
 mkdir ~/.ssh
 echo -e "Host *\nStrictHostKeyChecking no" > ~/.ssh/config


### PR DESCRIPTION
Mounting `/var/drydock` doesn't seem off, as Phabricator keeps leashes alive by default. This leads to problems when the DryDock container is restarted, as all working copy leashed will no longer exist yet be active in Phabricator.

By allowing to mount a volume/host dir, this can be prevented.